### PR TITLE
profilr url validation issue 4 solved

### DIFF
--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -113,3 +113,27 @@ def test_password_complexity_invalid(bad_password):
     }
     with pytest.raises(ValidationError):
         UserCreate(**invalid_data)
+
+import pytest
+from pydantic import ValidationError
+from app.schemas.user_schemas import UserBase
+
+@pytest.mark.parametrize("valid_url", [
+    "http://example.com/picture.jpg",
+    "https://example.com/photo.png",
+    None
+])
+def test_valid_profile_picture_url(valid_url, user_base_data):
+    user_base_data["profile_picture_url"] = valid_url
+    user = UserBase(**user_base_data)
+    assert user.profile_picture_url == valid_url
+
+@pytest.mark.parametrize("invalid_url", [
+    "ftp://example.com/picture.jpg",  # Invalid scheme
+    "example.com/photo.png",          # Missing scheme
+    "http:/example.com",              # Malformed scheme
+])
+def test_invalid_profile_picture_url(invalid_url, user_base_data):
+    user_base_data["profile_picture_url"] = invalid_url
+    with pytest.raises(ValidationError):
+        UserBase(**user_base_data)


### PR DESCRIPTION
Updated validate_url Function:
The validator now imports and uses urlparse from the standard library. It parses the URL and checks two conditions:

The URL scheme must be either "http" or "https".
The parsed URL must have a valid domain (the netloc must not be empty).
If either condition fails, the function raises a ValueError with a message indicating that the URL is invalid.

Field Application:
The _validate_urls validator is applied to profile_picture_url, linkedin_profile_url, and github_profile_url fields, ensuring that any data provided to these fields passes the new validation.